### PR TITLE
Fix a flaky test

### DIFF
--- a/core/src/test/java/com/adobe/prime/core/sightly/models/EmbeddableWidgetModelTest.java
+++ b/core/src/test/java/com/adobe/prime/core/sightly/models/EmbeddableWidgetModelTest.java
@@ -34,6 +34,7 @@ import com.adobe.prime.core.services.EmbeddableWidgetConfigurationService;
 import com.adobe.prime.core.services.EmbeddableWidgetService;
 import com.day.cq.wcm.api.Page;
 import com.day.cq.wcm.scripting.WCMBindingsConstants;
+import com.google.gson.*;
 
 import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
@@ -90,7 +91,8 @@ public class EmbeddableWidgetModelTest
     String expectedConfigs =
         "{\"widgetRefSelected\":\"com.adobe.captivateprime.lostrip.trending\",\"auth\":{\"accessToken\":\"123456\"},\"type\":\"acapConfig\",\"widgetConfig\":{\"widgetRef\":\"com.adobe.captivateprime.lostrip.trending\"}}";
     String configs = widgetModel.getWidgetConfigs();
-    assertTrue(expectedConfigs.equals(configs));
+    assertTrue(JsonParser.parseString(configs).equals(JsonParser.parseString(expectedConfigs)));
+
   }
 
   @Test

--- a/core/src/test/java/com/adobe/prime/core/sightly/models/EmbeddableWidgetModelTest.java
+++ b/core/src/test/java/com/adobe/prime/core/sightly/models/EmbeddableWidgetModelTest.java
@@ -34,7 +34,7 @@ import com.adobe.prime.core.services.EmbeddableWidgetConfigurationService;
 import com.adobe.prime.core.services.EmbeddableWidgetService;
 import com.day.cq.wcm.api.Page;
 import com.day.cq.wcm.scripting.WCMBindingsConstants;
-import com.google.gson.*;
+import com.google.gson.JsonParser;
 
 import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;

--- a/core/src/test/java/com/adobe/prime/core/sightly/models/EmbeddableWidgetModelTest.java
+++ b/core/src/test/java/com/adobe/prime/core/sightly/models/EmbeddableWidgetModelTest.java
@@ -92,7 +92,6 @@ public class EmbeddableWidgetModelTest
         "{\"widgetRefSelected\":\"com.adobe.captivateprime.lostrip.trending\",\"auth\":{\"accessToken\":\"123456\"},\"type\":\"acapConfig\",\"widgetConfig\":{\"widgetRef\":\"com.adobe.captivateprime.lostrip.trending\"}}";
     String configs = widgetModel.getWidgetConfigs();
     assertTrue(JsonParser.parseString(configs).equals(JsonParser.parseString(expectedConfigs)));
-
   }
 
   @Test


### PR DESCRIPTION
**Description:**
The test `com.adobe.prime.core.sightly.models.EmbeddableWidgetModelTest#testWidgetConfigs` may fail due to the non-deterministic order of iteration of _HashMap_ . To be more specific, `getWidgetConfig()` returns `widgetObject` that is a `HashMap`. The iteration order of it isn't guaranteed to be that of elements put into it.
One can check the problem using [NonDex](https://github.com/TestingResearchIllinois/NonDex):
```
mvn install -pl core -DskipTests
mvn -pl core edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=com.adobe.prime.core.sightly.models.EmbeddableWidgetModelTest#testWidgetConfigs
```
**Solution**
Instead of changing the main code, i.e., using _LinkedHashMap_ rather than _HashMap_, we can just modify the test function by utilizing GSON's `JsonParser`. Comparison between two `JsonElement` generated by `JsonParser` will ignore the order.